### PR TITLE
Najnowsze zmiany

### DIFF
--- a/ubuntu22apache2php81/README.md
+++ b/ubuntu22apache2php81/README.md
@@ -1,3 +1,12 @@
+# Informacje
 - Ubuntu 22.10
 - PHP 8.1
 - Apache2
+
+# Changelog:
+### 15.07.2022
+- Dodano brakujacy pakiet iproute2
+- Poprawiono plik 000-default.conf który nie uruchamiał skryptów php za pomocą fpm
+- Dodano import pliku xdebug-init.sh
+- Zoptymalizowano plik xdebug-init.sh
+- Poprawiono uruchamianie php8.1-fpm

--- a/ubuntu22apache2php81/dockerfile
+++ b/ubuntu22apache2php81/dockerfile
@@ -3,10 +3,12 @@ FROM ubuntu:22.10
 ARG DEBIAN_FRONTEND=noninteractive
 ENV WEBROOT_PATH="/var/www/html"
 
-LABEL org.opencontainers.image.authors="krzysztofzylka@yahoo.com"
+LABEL name="krzysztofzylka/ubuntu22apache2php81"
+LABEL maintainer="krzysztofzylka@yahoo.com"
+LABEL build-date="2022-07-15"
 
 RUN apt update -y && apt upgrade -y
-RUN apt -y install software-properties-common
+RUN apt -y install software-properties-common iproute2
 
 RUN apt -y install apache2 libapache2-mod-fcgid && \
 a2enmod rewrite actions fcgid alias proxy_fcgi
@@ -19,6 +21,7 @@ RUN apt-get update && apt install -y php8.1-cli php8.1-fpm php8.1-common php8.1-
 
 COPY src/php/xdebug.ini /etc/php/8.1/mods-available/xdebug.ini
 
+ADD src/xdebug-init.sh /xdebug-init.sh
 ADD src/start.sh /start.sh
 
 EXPOSE 80

--- a/ubuntu22apache2php81/src/000-default.conf
+++ b/ubuntu22apache2php81/src/000-default.conf
@@ -10,5 +10,9 @@
         AllowOverride All
         Require all granted
     </Directory>
-</VirtualHost>
 
+    <FilesMatch \.php$>
+            # Apache 2.4.10+ can proxy to unix socket
+            SetHandler "proxy:unix:/var/run/php/php8.1-fpm.sock|fcgi://localhost/"
+    </FilesMatch>
+</VirtualHost>

--- a/ubuntu22apache2php81/src/start.sh
+++ b/ubuntu22apache2php81/src/start.sh
@@ -1,2 +1,3 @@
 bash /xdebug-init.sh
+service php8.1-fpm start
 apache2ctl -D FOREGROUND

--- a/ubuntu22apache2php81/src/xdebug-init.sh
+++ b/ubuntu22apache2php81/src/xdebug-init.sh
@@ -1,4 +1,4 @@
-HOSTIP=$(/sbin/ip route|awk '/default/ { print $3 }')
+HOSTIP=$(ip route|awk '/default/ { print $3 }')
 XDEBUG_PATH="/etc/php/8.1/mods-available/xdebug.ini"
 
 sed -i "s/xdebug.client_host=.*/xdebug.client_host=$HOSTIP/g" $XDEBUG_PATH


### PR DESCRIPTION
- Dodano brakujacy pakiet iproute2
- Poprawiono plik 000-default.conf który nie uruchamiał skryptów php za pomocą fpm
- Dodano import pliku xdebug-init.sh
- Zoptymalizowano plik xdebug-init.sh
- Poprawiono uruchamianie php8.1-fpm